### PR TITLE
to see if the infinity sign is returned in google error

### DIFF
--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -16,7 +16,8 @@ module OAuth2
         message << "#{@code}: #{@description}"
       end
 
-      message << response.body
+      #https://github.com/intridea/oauth2/issues/155
+      message << response.body.force_encoding("UTF-8")
 
       super(message.join("\n"))
     end


### PR DESCRIPTION
https://github.com/intridea/oauth2/issues/155

```
Error message
Encoding::CompatibilityError: incompatible character encodings: UTF-8 and ASCII-8BIT

Stack trace (show Rails)
…1/bundler/gems/oauth2-7018e7af6655/lib/oauth2/
error.rb:  21:in `join'
```
