### PR TITLE
Fixing assertion strategy to accept claim key overrides, allowing grant type overrides and removing assertion_type and scope from headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ log/*
 measurement/*
 pkg/*
 rdoc/*
+.idea

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -44,6 +44,9 @@ Lint/UnusedBlockArgument:
     - 'vendor/**/*'
     - '**/.irbrc'
 
+RSpec/NestedGroups:
+  Enabled: false
+
 Style/ClassVars:
   Enabled: false
 

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -16,7 +16,8 @@ module OAuth2
         message << "#{@code}: #{@description}"
       end
 
-      message << response.body
+      #https://github.com/intridea/oauth2/issues/155
+      message << response.body.force_encoding("UTF-8")
 
       super(message.join("\n"))
     end

--- a/lib/oauth2/error.rb
+++ b/lib/oauth2/error.rb
@@ -26,11 +26,11 @@ module OAuth2
       opts[:error_description] && message << opts[:error_description]
 
       error_message = if opts[:error_description] && opts[:error_description].respond_to?(:encoding)
-        script_encoding = opts[:error_description].encoding
-        response_body.encode(script_encoding, :invalid => :replace, :undef => :replace)
-      else
-        response_body
-      end
+                        script_encoding = opts[:error_description].encoding
+                        response_body.encode(script_encoding, :invalid => :replace, :undef => :replace)
+                      else
+                        response_body
+                      end
 
       message << error_message
 

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -49,10 +49,12 @@ module OAuth2
 
       def build_request(params)
         assertion = build_assertion(params)
-        request_hash = {}
-        request_hash[:grant_type] = params[:grant_type] || 'urn:ietf:params:oauth:grant-type:jwt-bearer'
-        request_hash[:assertion] = assertion
-        request_hash.merge!(client_params)
+        grant_type = params[:grant_type] || 'urn:ietf:params:oauth:grant-type:jwt-bearer'
+        
+        {
+          :grant_type => grant_type,
+          :assertion => assertion
+        }
       end
 
       def build_assertion(params)

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -15,10 +15,15 @@ module OAuth2
     #     :iss => "http://localhost:3001",
     #     :aud => "http://localhost:8080/oauth2/token"
     #     :sub => "me@example.com",
-    #     :exp => Time.now.utc.to_i + 3600
+    #     :exp => Time.now.utc.to_i + 3600,
     #   }
     #
-    #   access = client.assertion.get_token(claimset, :algorithm => 'HS256', :key => 'secret_key')
+    #   encoding = {
+    #     :algorithm => 'HS256',
+    #     :key => 'secret_key',
+    #   }
+    #
+    #   access = client.assertion.get_token(claimset, encoding)
     #   access.token                 # actual access_token string
     #   access.get("/api/stuff")     # making api calls with access token in header
     #

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -64,8 +64,8 @@ module OAuth2
       #   @see https://tools.ietf.org/html/rfc7518#section-3.1
       #
       # The object type of `:key` may depend on the value of `:algorithm`.  Sample arguments:
-      #   get_token(claimset, :algorithm => 'HS256', :key => 'secret_key')
-      #   get_token(claimset, :algorithm => 'RS256', :key => OpenSSL::PKCS12.new(File.read('my_key.p12'), 'not_secret'))
+      #   get_token(claimset, {:algorithm => 'HS256', :key => 'secret_key'})
+      #   get_token(claimset, {:algorithm => 'RS256', :key => OpenSSL::PKCS12.new(File.read('my_key.p12'), 'not_secret')})
       #
       # @param [Hash] request_opts options that will be used to assemble the request
       # @option request_opts [String] :scope the url parameter `scope` that may be required by some endpoints

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -4,19 +4,21 @@ module OAuth2
   module Strategy
     # The Client Assertion Strategy
     #
-    # @see http://tools.ietf.org/html/draft-ietf-oauth-v2-10#section-4.1.3
+    # @see https://tools.ietf.org/html/rfc7523
     #
     # Sample usage:
     #   client = OAuth2::Client.new(client_id, client_secret,
-    #                               :site => 'http://localhost:8080')
+    #                               :site => 'http://localhost:8080',
+    #                               :auth_scheme => :request_body)
     #
-    #   params = {:hmac_secret => "some secret",
-    #             # or :private_key => "private key string",
-    #             :iss => "http://localhost:3001",
-    #             :prn => "me@here.com",
-    #             :exp => Time.now.utc.to_i + 3600}
+    #   claimset = {
+    #     :iss => "http://localhost:3001",
+    #     :aud => "http://localhost:8080/oauth2/token"
+    #     :sub => "me@example.com",
+    #     :exp => Time.now.utc.to_i + 3600
+    #   }
     #
-    #   access = client.assertion.get_token(params)
+    #   access = client.assertion.get_token(claimset, 'HS256', 'secret_key')
     #   access.token                 # actual access_token string
     #   access.get("/api/stuff")     # making api calls with access token in header
     #
@@ -30,56 +32,57 @@ module OAuth2
 
       # Retrieve an access token given the specified client.
       #
-      # @param [Hash] params assertion params
-      # pass either :hmac_secret or :private_key, but not both.
-      #
-      #   params :hmac_secret, secret string.
-      #   params :private_key, private key string.
-      #
-      # for possible claim keys, see https://tools.ietf.org/html/rfc7519#section-4.1
-      #
-      #   params :iss, issuer
-      #   params :aud, audience, optional
-      #   params :prn, principal, current user
-      #     ^ DEPRECATED: prn is now 'sub' https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#appendix-F
-      #   params :exp, expired at, in seconds, like Time.now.utc.to_i + 3600
-      #
-      # @param [Hash] opts options
-      def get_token(params = {}, opts = {})
-        hash = build_request(params)
-        @client.get_token(hash, opts.merge('refresh_token' => nil))
-      end
-
-      def build_request(params)
-        url_params = params[:url_params] || {}
-        claims = params[:claims] || {}
-        encoding_options = choose_algorithm!(params)
-
-        {
-          :grant_type => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
-          :assertion => build_assertion(claims, encoding_options),
-        }.merge(url_params)
+      # @param [Hash] claims the hash representation of the claims that should be encoded as a JWT (JSON Web Token)
+      # 
+      # For reading on JWT and claim keys:
+      #   @see https://github.com/jwt/ruby-jwt
+      #   @see https://tools.ietf.org/html/rfc7519#section-4.1
+      #   @see https://www.iana.org/assignments/jwt/jwt.xhtml
+      # 
+      # There are many possible claim keys, and applications may ask for their own custom keys.
+      # Some typically required ones:
+      # 
+      #   :iss (issuer)
+      #   :aud (audience)
+      #   :sub (subject) -- formerly :prn https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#appendix-F   
+      #   :exp, (expiration time) -- in seconds, e.g. Time.now.utc.to_i + 3600     
+      # 
+      # @param [String] algorithm the algorithm with which you would like the JWT to be encoded.
+      # @param [Object] key the key with which you would like to encode the JWT
+      # 
+      # These two arguments are passed directly to `JWT.encode`.  For supported encoding arguments:
+      #   @see https://github.com/jwt/ruby-jwt#algorithms-and-usage
+      #   @see https://tools.ietf.org/html/rfc7518#section-3.1
+      # 
+      # The object type of `key` may depend on the value of `algorithm`.  Sample arguments:
+      #   client.assertion.get_token(claimset, 'HS256', 'secret_key')
+      #   client.assertion.get_token(claimset, 'RS256', OpenSSL::PKCS12.new(File.read('my_key.p12'), 'not_secret'))
+      # 
+      # @param [Hash] request_opts options that will be used to assemble the request
+      # @option request_opts [String] :scope the url parameter `scope` that may be required by some endpoints
+      #   @see https://tools.ietf.org/html/rfc7521#section-4.1
+      # 
+      # @param [Hash] response_opts this will be merged with the token response to create the AccessToken object
+      #   @see the access_token_opts argument to Client#get_token 
+      
+      def get_token(claims, algorithm, key, request_opts = {}, response_opts = {})
+        assertion = build_assertion(claims, algorithm, key)
+        params = build_request(assertion, request_opts)
+        
+        @client.get_token(params, response_opts.merge('refresh_token' => nil))
       end
 
     private
 
-      def choose_algorithm!(params)
-        # Right now there is only the choice of HS256 or RS256, but this could be expanded
-
-        private_key = params.delete(:private_key)
-        hmac_secret = params.delete(:hmac_secret)
-
-        if hmac_secret
-          {:algorithm => 'HS256', :key => hmac_secret}
-        elsif private_key
-          {:algorithm => 'RS256', :key => private_key}
-        else
-          raise ArgumentError.new(:message => 'Either hmac_secret or private_key is required for JWT encoding!')
-        end
+      def build_request(assertion, request_opts = {})
+        {
+          :grant_type => 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          :assertion => assertion,
+        }.merge(request_opts)
       end
 
-      def build_assertion(claims, encoding_options)
-        JWT.encode(claims, encoding_options[:key], encoding_options[:algorithm])
+      def build_assertion(claims, algorithm, key)
+        JWT.encode(claims, key, algorithm)
       end
     end
   end

--- a/lib/oauth2/strategy/assertion.rb
+++ b/lib/oauth2/strategy/assertion.rb
@@ -33,42 +33,42 @@ module OAuth2
       # Retrieve an access token given the specified client.
       #
       # @param [Hash] claims the hash representation of the claims that should be encoded as a JWT (JSON Web Token)
-      # 
+      #
       # For reading on JWT and claim keys:
       #   @see https://github.com/jwt/ruby-jwt
       #   @see https://tools.ietf.org/html/rfc7519#section-4.1
       #   @see https://www.iana.org/assignments/jwt/jwt.xhtml
-      # 
+      #
       # There are many possible claim keys, and applications may ask for their own custom keys.
       # Some typically required ones:
-      # 
+      #
       #   :iss (issuer)
       #   :aud (audience)
-      #   :sub (subject) -- formerly :prn https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#appendix-F   
-      #   :exp, (expiration time) -- in seconds, e.g. Time.now.utc.to_i + 3600     
-      # 
+      #   :sub (subject) -- formerly :prn https://tools.ietf.org/html/draft-ietf-oauth-json-web-token-06#appendix-F
+      #   :exp, (expiration time) -- in seconds, e.g. Time.now.utc.to_i + 3600
+      #
       # @param [String] algorithm the algorithm with which you would like the JWT to be encoded.
       # @param [Object] key the key with which you would like to encode the JWT
-      # 
+      #
       # These two arguments are passed directly to `JWT.encode`.  For supported encoding arguments:
       #   @see https://github.com/jwt/ruby-jwt#algorithms-and-usage
       #   @see https://tools.ietf.org/html/rfc7518#section-3.1
-      # 
+      #
       # The object type of `key` may depend on the value of `algorithm`.  Sample arguments:
       #   client.assertion.get_token(claimset, 'HS256', 'secret_key')
       #   client.assertion.get_token(claimset, 'RS256', OpenSSL::PKCS12.new(File.read('my_key.p12'), 'not_secret'))
-      # 
+      #
       # @param [Hash] request_opts options that will be used to assemble the request
       # @option request_opts [String] :scope the url parameter `scope` that may be required by some endpoints
       #   @see https://tools.ietf.org/html/rfc7521#section-4.1
-      # 
+      #
       # @param [Hash] response_opts this will be merged with the token response to create the AccessToken object
-      #   @see the access_token_opts argument to Client#get_token 
-      
+      #   @see the access_token_opts argument to Client#get_token
+
       def get_token(claims, algorithm, key, request_opts = {}, response_opts = {})
         assertion = build_assertion(claims, algorithm, key)
         params = build_request(assertion, request_opts)
-        
+
         @client.get_token(params, response_opts.merge('refresh_token' => nil))
       end
 

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -52,29 +52,33 @@ RSpec.describe OAuth2::Strategy::Assertion do
       @response_format = 'json'
     end
 
-    describe 'JWT assertion' do
+    describe 'assembling a JWT assertion' do
+      let(:jwt) do
+        payload, header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
+        {:payload => payload, :header => header}
+      end
+
+      let(:payload) { jwt[:payload] }
+      let(:header) { jwt[:header] }
+
       context 'when encoding as HS256' do
         let(:algorithm) { 'HS256' }
         let(:key) { 'super_secret!' }
 
         before do
           subject.get_token(claims, algorithm, key)
+          raise 'No request made!' if @request_body.nil?
         end
 
         it 'indicates HS256 in the header' do
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
-          coded_header = @request_body[:assertion].split('.').first
-          header = JWT::Decode.base64url_decode(coded_header)
-          expect(MultiJson.decode(header)['alg']).to eq('HS256')
+          expect(header).not_to be_nil
+          expect(header['alg']).to eq('HS256')
         end
 
         it 'encodes the JWT as HS256' do
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
-          jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
-          expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
-          jwt.each do |key, claim|
+          expect(payload).not_to be_nil
+          expect(payload.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
+          payload.each do |key, claim|
             expect(claims[key.to_sym]).to eq(claim)
           end
         end
@@ -86,22 +90,18 @@ RSpec.describe OAuth2::Strategy::Assertion do
 
         before do
           subject.get_token(claims, algorithm, key)
+          raise 'No request made!' if @request_body.nil?
         end
 
         it 'indicates RS256 in the header' do
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
-          coded_header = @request_body[:assertion].split('.').first
-          header = JWT::Decode.base64url_decode(coded_header)
-          expect(MultiJson.decode(header)['alg']).to eq('RS256')
+          expect(header).not_to be_nil
+          expect(header['alg']).to eq('RS256')
         end
 
         it 'encodes the JWT as RS256' do
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
-          jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
-          expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
-          jwt.each do |key, claim|
+          expect(payload).not_to be_nil
+          expect(payload.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
+          payload.each do |key, claim|
             expect(claims[key.to_sym]).to eq(claim)
           end
         end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe OAuth2::Strategy::Assertion do
     cli.connection.build do |b|
       b.adapter :test do |stub|
         stub.post('/oauth/token') do |env|
+          @request_body = env.body
+          
           case @mode
             when 'formencoded'
               [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']
@@ -20,26 +22,18 @@ RSpec.describe OAuth2::Strategy::Assertion do
     cli
   end
 
-  let(:key) { OpenSSL::PKey::RSA.new(1024) }
+  let(:algorithm) { 'HS256' }
+  let(:key) { 'arowana' }
   let(:timestamp) { Time.now.to_i }
-  let(:params) do
+  let(:claims) do
     {
-      :url_params => {
-        :custom_param => 'mackerel',
-        :scope => 'sole',
-      },
-
-      :claims => {
-        :iss => 'carp@example.com',
-        :scope => 'https://oauth.example.com/auth/flounder',
-        :aud => 'https://sturgeon.example.com/oauth2/token',
-        :exp => timestamp + 3600,
-        :iat => timestamp,
-        :sub => '12345',
-        :custom_claim => 'ling cod',
-      },
-
-      :private_key => key,
+      :iss => 'carp@example.com',
+      :scope => 'https://oauth.example.com/auth/flounder',
+      :aud => 'https://sturgeon.example.com/oauth2/token',
+      :exp => timestamp + 3600,
+      :iat => timestamp,
+      :sub => '12345',
+      :custom_claim => 'ling cod',
     }
   end
 
@@ -49,98 +43,122 @@ RSpec.describe OAuth2::Strategy::Assertion do
     end
   end
 
-  describe '#build_request' do
-    let(:request) { subject.build_request(params) }
+  describe '#get_token' do
+    before do
+      @mode = 'json'
+    end
+    
+    describe 'JWT assertion' do
+      context 'when encoding as HS256' do
+        let(:algorithm) { 'HS256' }
+        let(:key) { 'super_secret!' }
+        
+        before do
+          subject.get_token(claims, algorithm, key)
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
+        end
 
-    it 'assembles the request body params from params[:url_params] and the claims from params[:claims]' do
-      expect(request.keys).to match_array [:grant_type, :assertion, :custom_param, :scope]
-      expect(request[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
-      expect(request[:custom_param]).to eq('mackerel')
-      expect(request[:scope]).to eq('sole')
-      expect(request[:assertion]).not_to be_nil
+        it 'indicates HS256 in the header' do
+          coded_header = @request_body[:assertion].split('.').first
+          header = JWT::Decode.base64url_decode(coded_header)
+          expect(MultiJson.decode(header)['alg']).to eq('HS256')
+        end
+        
+        it 'encodes the JWT as HS256' do
+          jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
+          expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
+          jwt.each do |key, claim|
+            expect(claims[key.to_sym]).to eq(claim)
+          end
+        end
+      end
+      
+      context 'when encoding as RS256' do
+        let(:algorithm) { 'RS256' }
+        let(:key) { OpenSSL::PKey::RSA.new(1024) }
 
-      jwt, _header = JWT.decode(request[:assertion], key.public_key, true, :algorithm => 'RS256')
+        before do
+          subject.get_token(claims, algorithm, key)
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
+        end
 
-      expect(params[:claims].keys).to match_array(jwt.keys.map(&:to_sym))
-      params[:claims].each do |key, claim|
-        expect(jwt[key.to_s]).to eq(claim)
+        it 'indicates RS256 in the header' do
+          coded_header = @request_body[:assertion].split('.').first
+          header = JWT::Decode.base64url_decode(coded_header)
+          expect(MultiJson.decode(header)['alg']).to eq('RS256')
+        end
+
+        it 'encodes the JWT as RS256' do
+          jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
+          expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
+          jwt.each do |key, claim|
+            expect(claims[key.to_sym]).to eq(claim)
+          end
+        end
       end
     end
 
-    context 'when hmac_secret is passed in' do
-      before do
-        params.merge!(:hmac_secret => 'thisiskey')
-        params.delete(:private_key)
+    describe 'POST request parameters' do
+      it 'includes assertion and grant_type by default' do
+        subject.get_token(claims, algorithm, key)
+        expect(@request_body).not_to be_nil
+        expect(@request_body.keys).to match_array([:assertion, :grant_type])
+        expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+        expect(@request_body[:assertion]).to be_a(String) # tested in detail in JWT assertion contexts
       end
 
-      it 'encodes the JWT as HS256' do
-        coded_header = request[:assertion].split('.').first
-        header = JWT::Decode.base64url_decode(coded_header)
-        expect(MultiJson.decode(header)['alg']).to eq('HS256')
+      it 'includes others via request_options' do
+        subject.get_token(claims, algorithm, key, {:scope => 'dover sole'})
+        expect(@request_body).not_to be_nil
+        expect(@request_body.keys).to match_array([:assertion, :grant_type, :scope])
+        expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+        expect(@request_body[:assertion]).to be_a(String) # tested in detail in JWT assertion contexts
+        expect(@request_body[:scope]).to eq('dover sole')
+      end
+    end
+    
+    describe 'AccessToken options' do
+      it 'sets refresh_token to nil' do
+        token = subject.get_token(claims, algorithm, key)
+        expect(token).to be_an(AccessToken)
+        expect(token.params).to eq({})
+        expect(token.refresh_token).to eq(nil)
+      end
+      
+      it 'passes custom opts via request_options' do
+        custom_token_option = {:custom_token_option => 'mackerel'}
+        token = subject.get_token(claims, algorithm, key, {}, custom_token_option)
+        expect(token).to be_an(AccessToken)
+        expect(token.params).to eq(custom_token_option)
       end
     end
 
-    context 'when private_key is passed in' do
-      before do
-        expect(params[:private_key]).to be
-        expect(params).to_not have_key(:hmac_secret)
-      end
+    describe 'response type' do
+      %w[json formencoded].each do |mode|
+        context "when #{mode}" do
+          before do
+            @mode = mode
+            @access = subject.get_token(claims, algorithm, key)
+          end
 
-      it 'encodes the JWT as RS256' do
-        coded_header = request[:assertion].split('.').first
-        header = JWT::Decode.base64url_decode(coded_header)
-        expect(MultiJson.decode(header)['alg']).to eq('RS256')
-      end
-    end
+          it 'returns AccessToken with same Client' do
+            expect(@access.client).to eq(client)
+          end
 
-    context 'when neither private_key nor hmac_secret is passed in' do
-      before do
-        params.delete(:private_key)
-        expect(params).to_not have_key(:hmac_secret)
-      end
+          it 'returns AccessToken with #token' do
+            expect(@access.token).to eq('salmon')
+          end
 
-      it 'raises an argument error' do
-        expect { subject.build_request(params) }.to raise_error(ArgumentError, /hmac_secret or private_key/)
-      end
-    end
+          it 'returns AccessToken with #expires_in' do
+            expect(@access.expires_in).to eq(600)
+          end
 
-    context 'when both private_key and hmac_secret are passed in' do
-      before do
-        expect(params[:private_key]).to be
-        params.merge!(:hmac_secret => 'top_secret')
-      end
-
-      it 'defaults to HS256' do
-        coded_header = request[:assertion].split('.').first
-        header = JWT::Decode.base64url_decode(coded_header)
-        expect(MultiJson.decode(header)['alg']).to eq('HS256')
-      end
-    end
-  end
-
-  %w[json formencoded].each do |mode|
-    describe "#get_token (#{mode})" do
-      let(:params) { { :hmac_secret => "#{mode}-foo" } }
-
-      before do
-        @mode = mode
-        @access = subject.get_token(params)
-      end
-
-      it 'returns AccessToken with same Client' do
-        expect(@access.client).to eq(client)
-      end
-
-      it 'returns AccessToken with #token' do
-        expect(@access.token).to eq('salmon')
-      end
-
-      it 'returns AccessToken with #expires_in' do
-        expect(@access.expires_in).to eq(600)
-      end
-
-      it 'returns AccessToken with #expires_at' do
-        expect(@access.expires_at).not_to be_nil
+          it 'returns AccessToken with #expires_at' do
+            expect(@access.expires_at).not_to be_nil
+          end
+        end
       end
     end
   end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -4,38 +4,27 @@ RSpec.describe OAuth2::Strategy::Assertion do
   subject { client.assertion }
 
   let(:client) do
-    cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com')
+    cli = OAuth2::Client.new('abc', 'def', :site => 'http://api.example.com', :auth_scheme => auth_scheme)
     cli.connection.build do |b|
       b.adapter :test do |stub|
-        stub.post('/oauth/token') do |env|
-          @request_body = env.body
+        stub.post('/oauth/token') do |token_request|
+          @request_body = token_request.body
           
-          case @mode
-            when 'formencoded'
-              [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']
-            when 'json'
-              [200, {'Content-Type' => 'application/json'}, '{"expires_in":600,"access_token":"salmon","refresh_token":"trout"}']
+          case @response_format
+          when 'formencoded'
+            [200, {'Content-Type' => 'application/x-www-form-urlencoded'}, 'expires_in=600&access_token=salmon&refresh_token=trout']
+          when 'json'
+            [200, {'Content-Type' => 'application/json'}, '{"expires_in":600,"access_token":"salmon","refresh_token":"trout"}']
+          else
+            fail('Please define @response_format to choose a response content type!')  
           end
         end
       end
     end
     cli
   end
-
-  let(:algorithm) { 'HS256' }
-  let(:key) { 'arowana' }
-  let(:timestamp) { Time.now.to_i }
-  let(:claims) do
-    {
-      :iss => 'carp@example.com',
-      :scope => 'https://oauth.example.com/auth/flounder',
-      :aud => 'https://sturgeon.example.com/oauth2/token',
-      :exp => timestamp + 3600,
-      :iat => timestamp,
-      :sub => '12345',
-      :custom_claim => 'ling cod',
-    }
-  end
+  
+  let(:auth_scheme) { :request_body }
 
   describe '#authorize_url' do
     it 'raises NotImplementedError' do
@@ -44,8 +33,23 @@ RSpec.describe OAuth2::Strategy::Assertion do
   end
 
   describe '#get_token' do
+    let(:algorithm) { 'HS256' }
+    let(:key) { 'arowana' }
+    let(:timestamp) { Time.now.to_i }
+    let(:claims) do
+      {
+        :iss => 'carp@example.com',
+        :scope => 'https://oauth.example.com/auth/flounder',
+        :aud => 'https://sturgeon.example.com/oauth2/token',
+        :exp => timestamp + 3600,
+        :iat => timestamp,
+        :sub => '12345',
+        :custom_claim => 'ling cod',
+      }
+    end
+    
     before do
-      @mode = 'json'
+      @response_format = 'json'
     end
     
     describe 'JWT assertion' do
@@ -103,70 +107,109 @@ RSpec.describe OAuth2::Strategy::Assertion do
         let(:algorithm) { 'the blockchain' }
         let(:key) { 'machine learning' }
         
-        it 'raises' do
+        it 'raises NotImplementedError' do
           # this behavior is handled by the JWT gem, but this should make sure it is consistent
-          expect { subject.get_token(claims, algorithm, key) }.to raise_error
+          expect { subject.get_token(claims, algorithm, key) }.to raise_error(NotImplementedError)
         end
       end
     end
 
     describe 'POST request parameters' do
-      it 'includes assertion and grant_type by default' do
-        subject.get_token(claims, algorithm, key)
-        expect(@request_body).not_to be_nil
-        expect(@request_body.keys).to match_array([:assertion, :grant_type])
-        expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
-        expect(@request_body[:assertion]).to be_a(String) # tested in detail in JWT assertion contexts
-      end
+      context 'when using :auth_scheme => :request_body' do
+        let(:auth_scheme) { :request_body }
 
-      it 'includes others via request_options' do
-        subject.get_token(claims, algorithm, key, {:scope => 'dover sole'})
-        expect(@request_body).not_to be_nil
-        expect(@request_body.keys).to match_array([:assertion, :grant_type, :scope])
-        expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
-        expect(@request_body[:assertion]).to be_a(String) # tested in detail in JWT assertion contexts
-        expect(@request_body[:scope]).to eq('dover sole')
+        it 'includes assertion and grant_type, along with the client parameters' do
+          subject.get_token(claims, algorithm, key)
+          expect(@request_body).not_to be_nil
+          expect(@request_body.keys).to match_array([:assertion, :grant_type, 'client_id', 'client_secret'])
+          expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+          expect(@request_body[:assertion]).to be_a(String)
+          expect(@request_body['client_id']).to eq('abc')
+          expect(@request_body['client_secret']).to eq('def')
+        end
+
+        it 'includes other params via request_options' do
+          subject.get_token(claims, algorithm, key, {:scope => 'dover sole'})
+          expect(@request_body).not_to be_nil
+          expect(@request_body.keys).to match_array([:assertion, :grant_type, :scope, 'client_id', 'client_secret'])
+          expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+          expect(@request_body[:assertion]).to be_a(String)
+          expect(@request_body[:scope]).to eq('dover sole')
+          expect(@request_body['client_id']).to eq('abc')
+          expect(@request_body['client_secret']).to eq('def')
+        end
+      end
+      
+      context 'when using :auth_scheme => :basic_auth' do
+        let(:auth_scheme) { :basic_auth }
+        
+        it 'includes assertion and grant_type by default' do
+          subject.get_token(claims, algorithm, key)
+          expect(@request_body).not_to be_nil
+          expect(@request_body.keys).to match_array([:assertion, :grant_type])
+          expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+          expect(@request_body[:assertion]).to be_a(String)
+        end
+
+        it 'includes other params via request_options' do
+          subject.get_token(claims, algorithm, key, {:scope => 'dover sole'})
+          expect(@request_body).not_to be_nil
+          expect(@request_body.keys).to match_array([:assertion, :grant_type, :scope])
+          expect(@request_body[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+          expect(@request_body[:assertion]).to be_a(String)
+          expect(@request_body[:scope]).to eq('dover sole')
+        end
       end
     end
     
-    describe 'AccessToken options' do
-      it 'sets refresh_token to nil' do
-        token = subject.get_token(claims, algorithm, key)
-        expect(token).to be_an(AccessToken)
-        expect(token.params).to eq({})
-        expect(token.refresh_token).to eq(nil)
-      end
+    describe 'returning the response' do
+      let(:access_token) { subject.get_token(claims, algorithm, key, {}, response_opts) }
+      let(:response_opts) { {} }
       
-      it 'passes custom opts via request_options' do
-        custom_token_option = {:custom_token_option => 'mackerel'}
-        token = subject.get_token(claims, algorithm, key, {}, custom_token_option)
-        expect(token).to be_an(AccessToken)
-        expect(token.params).to eq(custom_token_option)
-      end
-    end
-
-    describe 'response type' do
       %w[json formencoded].each do |mode|
-        context "when #{mode}" do
+        context "when the content type is #{mode}" do
           before do
-            @mode = mode
-            @access = subject.get_token(claims, algorithm, key)
+            @response_format = mode
+          end
+
+          it 'returns an AccessToken' do
+            expect(access_token).to be_an(AccessToken)
           end
 
           it 'returns AccessToken with same Client' do
-            expect(@access.client).to eq(client)
+            expect(access_token.client).to eq(client)
           end
 
           it 'returns AccessToken with #token' do
-            expect(@access.token).to eq('salmon')
+            expect(access_token.token).to eq('salmon')
           end
 
           it 'returns AccessToken with #expires_in' do
-            expect(@access.expires_in).to eq(600)
+            expect(access_token.expires_in).to eq(600)
           end
 
           it 'returns AccessToken with #expires_at' do
-            expect(@access.expires_at).not_to be_nil
+            expect(access_token.expires_at).not_to be_nil
+          end
+          
+          it 'sets AccessToken#refresh_token to nil' do
+            expect(access_token.refresh_token).to eq(nil)
+          end
+
+          context 'with custom response_opts' do
+            let(:response_opts) { {:custom_token_option => 'mackerel'} }
+
+            it 'passes them into the token params' do
+              expect(access_token.params).to eq(response_opts)
+            end
+          end
+
+          context 'when no custom opts are passed in' do
+            let(:response_opts) { {} }
+
+            it 'does not set any params by default' do
+              expect(access_token.params).to eq({})
+            end
           end
         end
       end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -116,35 +116,6 @@ RSpec.describe OAuth2::Strategy::Assertion do
         expect(MultiJson.decode(header)['alg']).to eq('HS256')
       end
     end
-
-    describe 'legacy backwards-compatible gem behavior' do
-      # in previous versions, all params were sent in at the top level because there was no way to differentiate
-      # a value from being put in the claimset vs into the request body
-
-      # this reproduces the behavior prior to 1.5.0, and can be removed when extract_legacy_params! is removed
-
-      let(:params) do
-        {
-          :iss => 'test test test',
-          :scope => 'https://www.example.com/auth/calendar',
-          :aud => 'https://oauth.example.com/oauth2/token',
-          :exp => timestamp + 3600,
-          :prn => 'bob@example.com',
-          :private_key => key,
-        }
-      end
-
-      it 'defaults to putting params[:scope] into the request body' do
-        expect(request.keys).to match_array [:grant_type, :assertion, :scope]
-        expect(request[:scope]).to eq('https://www.example.com/auth/calendar')
-      end
-
-      it 'defaults to putting :iss, :aud, :prn, and :exp into the JWT claimset' do
-        expect(request.keys).to match_array [:grant_type, :assertion, :scope]
-        jwt, _header = JWT.decode(request[:assertion], key.public_key, true, :algorithm => 'RS256')
-        expect(jwt.keys).to match_array(%w[iss aud prn exp])
-      end
-    end
   end
 
   %w[json formencoded].each do |mode|

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -1,3 +1,5 @@
+require 'jwt'
+
 RSpec.describe OAuth2::Strategy::Assertion do
   subject { client.assertion }
 

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -28,6 +28,82 @@ describe OAuth2::Strategy::Assertion do
     end
   end
 
+  context "when putting together a request" do
+    before do
+      @key = OpenSSL::PKey::RSA.new(1024)
+      @params = {:iss => 'google_api_account_name@developer.gserviceaccount.com',
+                 :scope => 'https://www.googleapis.com/auth/calendar',
+                 :aud => 'https://accounts.google.com/o/oauth2/token',
+                 :exp => Time.now.to_i + 3600,
+                 :iat => Time.now.to_i,
+                 :private_key => @key}
+    end
+
+    describe "#build_request" do
+      it "assembles the request from the given params" do
+        request = subject.build_request(@params)
+        expect(request[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+        expect(request.keys).to match_array [:grant_type, :assertion, "client_id", "client_secret"]
+      end
+    end
+
+    describe "#build_assertion" do
+      it "applies the parameters and constructs the claims" do
+        assertion = subject.build_assertion(@params)
+
+        claim_keys = %w(iss scope aud exp iat)
+        jwt, _header = JWT.decode(assertion, @key.public_key)
+        expect(jwt.keys).to match_array(claim_keys)
+        claim_keys.each do |claim_key|
+          expect(jwt[claim_key]).to eq(@params[claim_key.to_sym])
+        end
+      end
+
+      it "optionally applies the prn param" do
+        assertion = subject.build_assertion(@params.merge!(:prn => 'swayze@roadhouse.com'))
+
+        claim_keys = %w(iss scope aud exp iat prn)
+        jwt, _header = JWT.decode(assertion, @key.public_key)
+        expect(jwt.keys).to match_array(claim_keys)
+        claim_keys.each do |claim_key|
+          expect(jwt[claim_key]).to eq(@params[claim_key.to_sym])
+        end
+      end
+
+      describe "JWT encoding" do
+        it "encodes as HS256 when hmac_secret is passed in" do
+          @params.merge!(:hmac_secret => 'thisiskey')
+          @params.delete(:private_key)
+
+          expect(@params[:private_key]).to_not be
+          expect(@params[:hmac_secret]).to be
+
+          assertion = subject.build_assertion(@params)
+          header = MultiJson.decode(JWT.base64url_decode(assertion.split('.').first))
+          expect(header['alg']).to eq('HS256')
+        end
+
+        it "encodes as RS256 when private_key is passed in" do
+          expect(@params[:private_key]).to be
+          expect(@params[:hmac_secret]).to_not be
+
+          assertion = subject.build_assertion(@params)
+          header = MultiJson.decode(JWT.base64url_decode(assertion.split('.').first))
+          expect(header['alg']).to eq('RS256')
+        end
+
+        it "raises an argument error when nothing is passed in" do
+          @params.delete(:private_key)
+
+          expect(@params[:private_key]).to_not be
+          expect(@params[:hmac_secret]).to_not be
+
+          expect(lambda{ subject.build_assertion(@params) }).to raise_error(ArgumentError, /hmac_secret or private_key/)
+        end
+      end
+    end
+  end
+
   %w(json formencoded).each do |mode|
     describe "#get_token (#{mode})" do
       before do
@@ -52,5 +128,4 @@ describe OAuth2::Strategy::Assertion do
       end
     end
   end
-
 end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -18,7 +18,18 @@ RSpec.describe OAuth2::Strategy::Assertion do
     cli
   end
 
-  let(:params) { {:hmac_secret => 'foo'} }
+  let(:key) { OpenSSL::PKey::RSA.new(1024) }
+  
+  let(:params) {
+    {
+      :iss => 'google_api_account_name@developer.gserviceaccount.com',
+      :scope => 'https://www.googleapis.com/auth/calendar',
+      :aud => 'https://accounts.google.com/o/oauth2/token',
+      :exp => Time.now.to_i + 3600,
+      :iat => Time.now.to_i,
+      :private_key => key
+    }
+  }
 
   describe '#authorize_url' do
     it 'raises NotImplementedError' do
@@ -26,84 +37,77 @@ RSpec.describe OAuth2::Strategy::Assertion do
     end
   end
 
-  context "when putting together a request" do
-    before do
-      @key = OpenSSL::PKey::RSA.new(1024)
-      @params = {:iss => 'google_api_account_name@developer.gserviceaccount.com',
-        :scope => 'https://www.googleapis.com/auth/calendar',
-        :aud => 'https://accounts.google.com/o/oauth2/token',
-        :exp => Time.now.to_i + 3600,
-        :iat => Time.now.to_i,
-        :private_key => @key}
+  describe '#build_request' do
+    it 'assembles the request from the given params' do
+      request = subject.build_request(params)
+      expect(request[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
+      expect(request.keys).to match_array [:grant_type, :assertion]
+      # TODO: client_id and client_secret were removed -- does this still work?
+    end
+  end
+
+  describe '#build_assertion' do
+    it 'applies the parameters and constructs the claims' do
+      expected_claim_keys = %w(iss scope aud exp iat)
+      assertion = subject.build_assertion(params)
+
+      jwt, _header = JWT.decode(assertion, key.public_key, true, { :algorithm => 'RS256' })
+      expect(jwt.keys).to match_array(expected_claim_keys)
+      expected_claim_keys.each do |claim_key|
+        expect(jwt[claim_key]).to eq(params[claim_key.to_sym])
+      end
     end
 
-    describe "#build_request" do
-      it "assembles the request from the given params" do
-        request = subject.build_request(@params)
-        expect(request[:grant_type]).to eq('urn:ietf:params:oauth:grant-type:jwt-bearer')
-        expect(request.keys).to match_array [:grant_type, :assertion, "client_id", "client_secret"]
+    it 'optionally applies the prn param' do
+      expected_claim_keys = %w(iss scope aud exp iat prn)
+      assertion = subject.build_assertion(params.merge!(:prn => 'swayze@roadhouse.example.com'))
+
+      jwt, _header = JWT.decode(assertion, key.public_key, true, { :algorithm => 'RS256' })
+      expect(jwt.keys).to match_array(expected_claim_keys)
+      expected_claim_keys.each do |claim_key|
+        expect(jwt[claim_key]).to eq(params[claim_key.to_sym])
       end
     end
 
-    describe "#build_assertion" do
-      it "applies the parameters and constructs the claims" do
-        assertion = subject.build_assertion(@params)
+    describe 'JWT encoding' do
+      it 'encodes as HS256 when hmac_secret is passed in' do
+        params.merge!(:hmac_secret => 'thisiskey')
+        params.delete(:private_key)
 
-        claim_keys = %w(iss scope aud exp iat)
-        jwt, _header = JWT.decode(assertion, @key.public_key)
-        expect(jwt.keys).to match_array(claim_keys)
-        claim_keys.each do |claim_key|
-          expect(jwt[claim_key]).to eq(@params[claim_key.to_sym])
-        end
+        expect(params[:private_key]).to_not be
+        expect(params[:hmac_secret]).to be
+
+        assertion = subject.build_assertion(params)
+        coded_header = assertion.split('.').first
+        header = JWT::Decode.base64url_decode(coded_header)
+        expect(MultiJson.decode(header)).to eq({ 'alg' => 'HS256' })
       end
 
-      it "optionally applies the prn param" do
-        assertion = subject.build_assertion(@params.merge!(:prn => 'swayze@roadhouse.com'))
+      it 'encodes as RS256 when private_key is passed in' do
+        expect(params[:private_key]).to be
+        expect(params[:hmac_secret]).to_not be
 
-        claim_keys = %w(iss scope aud exp iat prn)
-        jwt, _header = JWT.decode(assertion, @key.public_key)
-        expect(jwt.keys).to match_array(claim_keys)
-        claim_keys.each do |claim_key|
-          expect(jwt[claim_key]).to eq(@params[claim_key.to_sym])
-        end
+        assertion = subject.build_assertion(params)
+        coded_header = assertion.split('.').first
+        header = JWT::Decode.base64url_decode(coded_header)
+        expect(MultiJson.decode(header)).to eq({ 'alg' => 'RS256' })
       end
 
-      describe "JWT encoding" do
-        it "encodes as HS256 when hmac_secret is passed in" do
-          @params.merge!(:hmac_secret => 'thisiskey')
-          @params.delete(:private_key)
+      it 'raises an argument error when nothing is passed in' do
+        params.delete(:private_key)
 
-          expect(@params[:private_key]).to_not be
-          expect(@params[:hmac_secret]).to be
+        expect(params[:private_key]).to_not be
+        expect(params[:hmac_secret]).to_not be
 
-          assertion = subject.build_assertion(@params)
-          header = MultiJson.decode(JWT.base64url_decode(assertion.split('.').first))
-          expect(header['alg']).to eq('HS256')
-        end
-
-        it "encodes as RS256 when private_key is passed in" do
-          expect(@params[:private_key]).to be
-          expect(@params[:hmac_secret]).to_not be
-
-          assertion = subject.build_assertion(@params)
-          header = MultiJson.decode(JWT.base64url_decode(assertion.split('.').first))
-          expect(header['alg']).to eq('RS256')
-        end
-
-        it "raises an argument error when nothing is passed in" do
-          @params.delete(:private_key)
-
-          expect(@params[:private_key]).to_not be
-          expect(@params[:hmac_secret]).to_not be
-
-          expect(lambda{ subject.build_assertion(@params) }).to raise_error(ArgumentError, /hmac_secret or private_key/)
-        end
+        expect { subject.build_assertion(params) }.to raise_error(ArgumentError, /hmac_secret or private_key/)
       end
     end
   end
 
   %w(json formencoded).each do |mode|
     describe "#get_token (#{mode})" do
+      let(:params) { { :hmac_secret => "#{mode}-foo" } }
+      
       before do
         @mode = mode
         @access = subject.get_token(params)

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -59,17 +59,19 @@ RSpec.describe OAuth2::Strategy::Assertion do
 
         before do
           subject.get_token(claims, algorithm, key)
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
         end
 
         it 'indicates HS256 in the header' do
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
           coded_header = @request_body[:assertion].split('.').first
           header = JWT::Decode.base64url_decode(coded_header)
           expect(MultiJson.decode(header)['alg']).to eq('HS256')
         end
 
         it 'encodes the JWT as HS256' do
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
           jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
           expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
           jwt.each do |key, claim|
@@ -84,17 +86,19 @@ RSpec.describe OAuth2::Strategy::Assertion do
 
         before do
           subject.get_token(claims, algorithm, key)
-          expect(@request_body).not_to be_nil
-          expect(@request_body[:assertion]).not_to be_nil
         end
 
         it 'indicates RS256 in the header' do
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
           coded_header = @request_body[:assertion].split('.').first
           header = JWT::Decode.base64url_decode(coded_header)
           expect(MultiJson.decode(header)['alg']).to eq('RS256')
         end
 
         it 'encodes the JWT as RS256' do
+          expect(@request_body).not_to be_nil
+          expect(@request_body[:assertion]).not_to be_nil
           jwt, _header = JWT.decode(@request_body[:assertion], key, true, :algorithm => algorithm)
           expect(jwt.keys).to match_array(%w[iss scope aud exp iat sub custom_claim])
           jwt.each do |key, claim|

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -94,7 +94,7 @@ RSpec.describe OAuth2::Strategy::Assertion do
           assertion = subject.build_assertion(params)
           coded_header = assertion.split('.').first
           header = JWT::Decode.base64url_decode(coded_header)
-          expect(MultiJson.decode(header)).to eq({ 'alg' => 'HS256' })
+          expect(MultiJson.decode(header)['alg']).to eq('HS256')
         end
       end
       
@@ -108,7 +108,7 @@ RSpec.describe OAuth2::Strategy::Assertion do
           assertion = subject.build_assertion(params)
           coded_header = assertion.split('.').first
           header = JWT::Decode.base64url_decode(coded_header)
-          expect(MultiJson.decode(header)).to eq({ 'alg' => 'RS256' })
+          expect(MultiJson.decode(header)['alg']).to eq('RS256')
         end
       end
       
@@ -133,7 +133,7 @@ RSpec.describe OAuth2::Strategy::Assertion do
           assertion = subject.build_assertion(params)
           coded_header = assertion.split('.').first
           header = JWT::Decode.base64url_decode(coded_header)
-          expect(MultiJson.decode(header)).to eq({ 'alg' => 'HS256' })
+          expect(MultiJson.decode(header)['alg']).to eq('HS256')
         end
       end
     end

--- a/spec/oauth2/strategy/assertion_spec.rb
+++ b/spec/oauth2/strategy/assertion_spec.rb
@@ -98,6 +98,16 @@ RSpec.describe OAuth2::Strategy::Assertion do
           end
         end
       end
+      
+      context 'with bad encoding params' do
+        let(:algorithm) { 'the blockchain' }
+        let(:key) { 'machine learning' }
+        
+        it 'raises' do
+          # this behavior is handled by the JWT gem, but this should make sure it is consistent
+          expect { subject.get_token(claims, algorithm, key) }.to raise_error
+        end
+      end
     end
 
     describe 'POST request parameters' do


### PR DESCRIPTION
PR left here until https://github.com/intridea/oauth2/pull/220 is merged.
